### PR TITLE
Only initialize per-voice random values once.

### DIFF
--- a/2-multi.lua
+++ b/2-multi.lua
@@ -24,9 +24,9 @@ function init()
 
     softcut.rate_slew_time(i,rate_slew)
     softcut.level_slew_time(i,level_slew)
-
-    randomize_all()
   end
+  
+  randomize_all()
 end
 
 function randomize_all()


### PR DESCRIPTION
I think `randomize_all` can just be called once in `init`, rather than within the loop initializing the softcut voices. (No harm here, just extra invocations.)